### PR TITLE
Add Python extension module example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,3 +23,5 @@ find_package(aligator REQUIRED)
 
 add_executable(main main.cpp)
 target_link_libraries(main PRIVATE aligator::aligator)
+
+add_subdirectory(cpp-extension)

--- a/cpp-extension/CMakeLists.txt
+++ b/cpp-extension/CMakeLists.txt
@@ -1,0 +1,1 @@
+aligator_create_python_extension(example_extension WITH_SOABI module.cpp)

--- a/cpp-extension/module.cpp
+++ b/cpp-extension/module.cpp
@@ -1,0 +1,11 @@
+#include <eigenpy/eigenpy.hpp>
+#include <aligator/config.hpp>
+
+#define _MY_STRINGIFY(x) #x
+#define MY_STRINGIFY(x) _MY_STRINGIFY(x)
+
+BOOST_PYTHON_MODULE(PYTHON_MODULE_NAME) {
+  printf("Custom aligator C++ extension: %s\n",
+         MY_STRINGIFY(PYTHON_MODULE_NAME));
+  printf(" - Aligator version: %s\n", ALIGATOR_VERSION);
+}


### PR DESCRIPTION

We use the new macro `aligator_create_python_extension()` which will be added to aligator.
